### PR TITLE
chore(github): add issue templates and update PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a problem with a skill, agent, or council workflow
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the details below so we can investigate.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the package is affected?
+      options:
+        - Skill workflow (plan-feature, build-feature, etc.)
+        - Agent definition
+        - Council template
+        - Build script (scripts/build.sh)
+        - CI pipeline
+        - Documentation
+    validations:
+      required: true
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill/Agent/Council Name
+      description: Which specific skill, agent, or council is affected?
+      placeholder: e.g., review-code, security-engineer, architecture-council
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly and concisely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Run `/review-code` on a branch with...
+        2. The Security Engineer step...
+        3. Error occurs when...
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: AI Agent
+      description: Which AI coding agent are you using?
+      options:
+        - Claude Code
+        - Cursor
+        - Codex CLI
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other details — error messages, screenshots, agent version, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/andrewvaughan/agent-council/security/advisories/new
+    about: Report security vulnerabilities privately via GitHub Security Advisories
+  - name: Questions & Discussion
+    url: https://github.com/andrewvaughan/agent-council/discussions
+    about: Ask questions or start a discussion about skills and workflows

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,48 @@
+name: Feature Request
+description: Suggest a new skill, agent, council, or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new skill, agent persona, or council? We'd love to hear it!
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: What are you requesting?
+      options:
+        - New skill workflow
+        - New agent persona
+        - New council
+        - Improvement to existing skill
+        - Improvement to existing agent or council
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the feature or improvement you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem it solves
+      description: What problem does this address? What workflow gap does it fill?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered other approaches? What are the trade-offs?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other details — examples, references, mockups, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,95 +1,49 @@
 ## Description
 
-<!-- Provide a clear and concise description of the changes in this PR -->
+<!-- What does this PR do and why? -->
 
 ## Type of Change
 
-<!-- Mark the relevant option with an 'x' -->
-
-- [ ] 🚀 New feature (non-breaking change that adds functionality)
-- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] 📝 Documentation update
-- [ ] ♻️ Code refactoring (no functional changes)
-- [ ] ✅ Test additions or improvements
-- [ ] 🔧 Chore (dependencies, configs, build)
+- [ ] New skill, agent, or council
+- [ ] Improvement to existing skill/agent/council
+- [ ] Bug fix (workflow correction)
+- [ ] Documentation update
+- [ ] Build/CI change
+- [ ] Chore (dependencies, configs)
 
 ## Related Issues
 
-<!-- Link to related issues using keywords: Closes #123, Fixes #456, Relates to #789 -->
-
-Closes #
+<!-- Closes #NNN, Fixes #NNN, Relates to #NNN -->
 
 ## Changes Made
 
-<!-- List the specific changes made in this PR -->
+<!-- Key changes, organized by area -->
 
 -
 -
--
-
-## Screenshots / Videos
-
-<!-- If applicable, add screenshots or videos to demonstrate UI changes -->
 
 ## Testing
 
-<!-- Describe the tests you ran and how to reproduce them -->
-
-### Test Plan
-
-- [ ] Unit tests added/updated
-- [ ] Integration tests added/updated
-- [ ] E2E tests added/updated (if applicable)
-- [ ] Manual testing performed
-
-### How to Test
-
-<!-- Step-by-step instructions for reviewers to test the changes -->
-
-1.
-2.
-3.
+- [ ] `scripts/build.sh --check` passes (no drift)
+- [ ] All CI checks pass locally or expected to pass
+- [ ] Manually reviewed changed skill workflows for correctness
 
 ## Checklist
 
-<!-- Mark completed items with an 'x' -->
-
-- [ ] My code follows the project's style guidelines
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published
+- [ ] No technology-specific terms in SKILL.md files
+- [ ] No personal paths in committed files
+- [ ] Documentation updated (if user-facing change)
+- [ ] AGENTS.md updated (if adding/modifying skills, agents, or councils)
+- [ ] README.md updated (if changing counts or package description)
 
 ## Breaking Changes
 
-<!-- If this is a breaking change, describe the impact and migration path -->
+<!-- If skill workflows changed in ways that affect existing users, describe the impact -->
 
 N/A
 
 ## Deployment Notes
 
-<!-- Any special considerations for deployment? Database migrations? Environment variables? -->
+<!-- New environment requirements, migration steps, etc. -->
 
 N/A
-
-## Additional Context
-
-<!-- Add any other context about the PR here -->
-
----
-
-## For Reviewers
-
-<!-- Highlight specific areas you'd like feedback on -->
-
-**Focus areas for review:**
--
--
-
-**Questions for reviewers:**
--
--


### PR DESCRIPTION
## Description

Add GitHub issue templates and simplify the PR template to match a markdown skills package (not an application codebase).

## Type of Change

- [ ] New skill, agent, or council
- [ ] Improvement to existing skill/agent/council
- [ ] Bug fix (workflow correction)
- [ ] Documentation update
- [ ] Build/CI change
- [x] Chore (dependencies, configs)

## Changes Made

- **Bug report template** (`.github/ISSUE_TEMPLATE/bug-report.yml`): YAML form with component dropdown, AI agent selector, reproduction steps
- **Feature request template** (`.github/ISSUE_TEMPLATE/feature-request.yml`): YAML form for new skills/agents/councils/improvements
- **Template chooser** (`.github/ISSUE_TEMPLATE/config.yml`): Links to security advisories and discussions for non-issue inquiries
- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`): Simplified for skills package — removed screenshots, E2E tests, application-specific checklist items. Added skills-specific checks (no tech-stack terms, build drift, AGENTS.md updates)

## Testing

- [x] `scripts/build.sh --check` passes (no drift)
- [x] Manually reviewed YAML form syntax

## Checklist

- [x] No technology-specific terms in SKILL.md files
- [x] No personal paths in committed files
- [x] Documentation updated (if user-facing change)

## Breaking Changes

N/A

## Deployment Notes

N/A