### PR TITLE
feat(docs): add supplementary docs, checkpoint protocol, and agent compatibility template

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/agent-compatibility.yml
@@ -1,0 +1,90 @@
+name: Agent Compatibility Report
+description: Report how Agent Council works with a specific AI coding agent
+labels: ["compatibility"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve cross-agent support! Report your experience using Agent Council skills with any AI coding agent.
+
+  - type: input
+    id: agent-name
+    attributes:
+      label: Agent Name
+      description: Which AI coding agent did you test with?
+      placeholder: e.g., Cursor, Codex CLI, GitHub Copilot, Aider, Windsurf
+    validations:
+      required: true
+
+  - type: input
+    id: agent-version
+    attributes:
+      label: Agent Version
+      description: What version of the agent are you using?
+      placeholder: e.g., Cursor 0.45, Copilot Chat 1.2
+
+  - type: dropdown
+    id: skills-tested
+    attributes:
+      label: Skills Tested
+      description: Which skills did you test?
+      multiple: true
+      options:
+        - plan-feature
+        - build-feature
+        - build-api
+        - review-code
+        - submit-pr
+        - security-audit
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-worked
+    attributes:
+      label: What worked
+      description: Which features and workflow steps worked correctly?
+      placeholder: |
+        - File reading and editing worked well
+        - Council evaluation steps ran sequentially without issues
+        - Checkpoints paused for my review
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-didnt
+    attributes:
+      label: What didn't work
+      description: Which features or steps failed or required manual workarounds?
+      placeholder: |
+        - Slash command invocation not supported — had to reference SKILL.md directly
+        - GitHub CLI commands needed to be run manually in the terminal
+        - Model selection was ignored — agent used its default model
+
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Workarounds discovered
+      description: Any workarounds you found to make things work better?
+      placeholder: |
+        - Prompting "evaluate as the Security Engineer" worked for council steps
+        - Adding AGENTS.md to context helped the agent understand the workflow
+
+  - type: dropdown
+    id: overall-experience
+    attributes:
+      label: Overall experience
+      description: How would you rate the overall experience?
+      options:
+        - Works well with minor limitations
+        - Usable with workarounds
+        - Significant limitations
+        - Not practical for this agent
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other details — screenshots, error messages, configuration, etc.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full details on adding skills, agents
 | Document | Purpose |
 |----------|---------|
 | [AGENTS.md](AGENTS.md) | Full reference for AI agents — skills, councils, agents, configuration rules |
+| [Skills Reference](docs/SKILLS-REFERENCE.md) | Detailed per-skill documentation with step summaries and example output |
+| [Agent Compatibility](docs/AGENT-COMPATIBILITY.md) | Feature matrix and per-agent guidance for Claude Code, Cursor, Codex, and more |
+| [Customization Guide](docs/CUSTOMIZATION.md) | How to adapt skills, agents, and councils for your project |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to add skills, agents, councils, and submit changes |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting and security policy |
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Eleven specialized perspectives that staff the councils:
 | Backend Specialist | API design, services, data access, performance |
 | Platform Engineer | Infrastructure, deployment, monitoring, reliability |
 | DevX Engineer | Documentation, developer experience, onboarding |
-| Product Manager | User value, scope, prioritization, success metrics |
-| Technical Writer | Clarity, completeness, audience-appropriate docs |
-| UX Designer | Usability, interaction design, accessibility |
-| Data Analyst | Metrics, analytics, data-driven decisions |
+| Product Strategist | Product vision, user needs, feature prioritization, go-to-market |
+| Lean Delivery Lead | Rapid iteration, feature flags, incremental delivery, shipping speed |
+| Design Lead | UI/UX design, design systems, accessibility, usability |
+| Business Operations Lead | Cost management, ROI analysis, resource allocation, operational impact |
 
 Each agent has complexity tiers (Standard and Advanced) that scale review depth based on the significance of the decision.
 
@@ -130,7 +130,7 @@ Implementation skills (`build-feature`, `build-api`) are technology-agnostic —
 | Codex CLI | Partial | Reference AGENTS.md, follow skill steps manually |
 | Other agents | Manual | Any agent that reads markdown can follow the structured workflows |
 
-Skills are plain markdown — no proprietary format, no runtime dependencies. Any AI coding agent that can read files and follow instructions can use them.
+Skills are plain markdown — no proprietary format, no runtime dependencies. Any AI coding agent that can read files and follow instructions can use them. For detailed per-agent setup instructions, workarounds, and a full feature matrix, see the [Agent Compatibility guide](docs/AGENT-COMPATIBILITY.md).
 
 ## Customization
 
@@ -139,6 +139,8 @@ Tailor the workflows to your project:
 - **Add an agent** — Create a `.md` file in `canonical/agents/` following the existing persona format
 - **Modify a council** — Edit the council template in `canonical/councils/` to add or remove members
 - **Customize a skill** — Edit the workflow in `canonical/skills/` and rebuild
+
+For a comprehensive guide including tech stack configuration, agent persona customization with examples, and council composition changes, see the [Customization Guide](docs/CUSTOMIZATION.md).
 
 ### Build System
 

--- a/canonical/skills/build-api/SKILL.md
+++ b/canonical/skills/build-api/SKILL.md
@@ -11,6 +11,9 @@ Build backend API endpoints, services, and database changes following your proje
 > **Scope boundary**: This skill implements backend code and commits it. It does **NOT** create pull requests, push to remote, run code reviews, or submit anything for merge. When implementation and commits are complete, **stop** and suggest the user run `/review-code` next.
 
 > [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
+> [!WARNING]
 > **Tech stack required.** This skill adapts to your project's technology choices. If `AGENTS.md` does not specify a backend framework, ORM, API style, validation library, or test runner, **stop and ask the user** what their project uses. Then update `AGENTS.md` with a `## Tech Stack` section so future skills can reference it automatically. Example:
 >
 >     ## Tech Stack

--- a/canonical/skills/build-feature/SKILL.md
+++ b/canonical/skills/build-feature/SKILL.md
@@ -11,6 +11,9 @@ Execute a full-stack feature implementation across database, backend, frontend, 
 > **Scope boundary**: This skill implements code and commits it. It does **NOT** create pull requests, push to remote, run code reviews, or submit anything for merge. When implementation and commits are complete, **stop** and suggest the user run `/review-code` next. Do not proceed to PR creation — that is `/submit-pr`'s job.
 
 > [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
+> [!WARNING]
 > **Tech stack required.** This skill adapts to your project's technology choices. If `AGENTS.md` does not specify your project's frameworks, ORM, UI library, or test runner, **stop and ask the user** what their project uses. Then update `AGENTS.md` with a `## Tech Stack` section so future skills can reference it automatically. Example:
 >
 >     ## Tech Stack

--- a/canonical/skills/plan-feature/SKILL.md
+++ b/canonical/skills/plan-feature/SKILL.md
@@ -10,6 +10,9 @@ Take a feature idea from concept to an approved implementation plan with lean sc
 > [!CAUTION]
 > **Scope boundary**: This skill produces a _plan_, a decision record, and issue(s) in your project tracker. It does **NOT** write application code, create components, modify database schemas, run tests, create branches for implementation, or perform any build work. If the user asks to start building after the plan is approved, direct them to run `/build-feature <issue-number>` — do not begin implementation yourself.
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Gather Feature Context
 
 Ask the user to describe:

--- a/canonical/skills/review-code/SKILL.md
+++ b/canonical/skills/review-code/SKILL.md
@@ -10,6 +10,9 @@ Run a comprehensive, multi-perspective code review on the current branch changes
 > [!CAUTION]
 > **Scope boundary**: This skill reviews code and commits fixes. It does **NOT** create pull requests, push to remote, or merge anything. When the review is complete, **stop** and suggest the user run `/submit-pr` next. Do not proceed to PR creation — that is `/submit-pr`'s job.
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Analyze Current Changes
 
 Identify all changes on the current branch:

--- a/canonical/skills/security-audit/SKILL.md
+++ b/canonical/skills/security-audit/SKILL.md
@@ -10,6 +10,9 @@ Run a comprehensive security audit that combines automated static analysis, thre
 > [!CAUTION]
 > **Scope boundary**: This skill audits code and optionally remediates findings. It does **NOT** create pull requests, push to remote, or merge anything. When the audit is complete, **stop** and suggest the appropriate next step (see Step 9).
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Define Audit Scope
 
 Ask the user:

--- a/canonical/skills/submit-pr/SKILL.md
+++ b/canonical/skills/submit-pr/SKILL.md
@@ -10,6 +10,9 @@ Create a well-documented pull request for the current feature branch, following 
 > [!CAUTION]
 > **Scope boundary**: This skill pushes code, creates pull requests, monitors CI, and commits CI fixes (with user approval). It does **NOT** implement new features or run formal code reviews. When the PR is created and CI passes, **stop** — the workflow is complete.
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Pre-Submission Checks
 
 Verify the branch is ready for a pull request:

--- a/docs/AGENT-COMPATIBILITY.md
+++ b/docs/AGENT-COMPATIBILITY.md
@@ -5,7 +5,7 @@ description: Per-agent compatibility matrix and platform-specific guidance for u
 
 # Agent Compatibility
 
-Agent Council skills are structured markdown workflows. Any AI coding agent that can read files and follow instructions can use them — the level of automation depends on the agent's capabilities.
+Agent Council skills are structured markdown workflows. Any AI coding agent that can read files and follow instructions can use them — the level of automation depends on the agent's capabilities. For details on what each skill does, see the [Skills Reference](SKILLS-REFERENCE.md). To customize skills for your project, see the [Customization Guide](CUSTOMIZATION.md).
 
 ## Feature Matrix
 
@@ -41,7 +41,7 @@ npx skills add andrewvaughan/agent-council
 
 **Usage**:
 
-- Invoke skills as slash commands: `/plan-feature`, `/build-feature`, `/review-code`, `/submit-pr`
+- Invoke skills as slash commands: `/plan-feature`, `/build-feature`, `/build-api`, `/review-code`, `/submit-pr`, `/security-audit`
 - Council members run in parallel via Task subagents
 - Checkpoints pause for user approval automatically
 - Model selection follows the `## Model` section in each agent definition

--- a/docs/AGENT-COMPATIBILITY.md
+++ b/docs/AGENT-COMPATIBILITY.md
@@ -1,0 +1,170 @@
+---
+type: reference
+description: Per-agent compatibility matrix and platform-specific guidance for using Agent Council skills.
+---
+
+# Agent Compatibility
+
+Agent Council skills are structured markdown workflows. Any AI coding agent that can read files and follow instructions can use them — the level of automation depends on the agent's capabilities.
+
+## Feature Matrix
+
+| Feature | Claude Code | Cursor | Codex CLI | GitHub Copilot | Aider | Other |
+|---------|:-----------:|:------:|:---------:|:--------------:|:-----:|:-----:|
+| Slash command invocation | Yes | No | No | No | No | No |
+| Task subagent spawning | Yes | No | No | No | No | No |
+| Parallel council evaluation | Yes | No | No | No | No | No |
+| Checkpoint pausing | Yes | Partial | No | No | No | No |
+| Model selection per agent | Yes | No | No | No | No | No |
+| GitHub CLI integration | Yes | Partial | Partial | Partial | Partial | Varies |
+| File reading and editing | Yes | Yes | Yes | Yes | Yes | Varies |
+| Multi-file changes | Yes | Yes | Yes | Yes | Yes | Varies |
+
+### Legend
+
+- **Yes** — Feature works natively with no workarounds
+- **Partial** — Feature works with manual steps or workarounds
+- **No** — Feature is not supported; must be done manually
+- **Varies** — Depends on the specific agent and configuration
+
+## Per-Agent Guidance
+
+### Claude Code (Full Support)
+
+Claude Code provides native support for Agent Council skills. All features work out of the box.
+
+**Setup**:
+
+```bash
+npx skills add andrewvaughan/agent-council
+```
+
+**Usage**:
+
+- Invoke skills as slash commands: `/plan-feature`, `/build-feature`, `/review-code`, `/submit-pr`
+- Council members run in parallel via Task subagents
+- Checkpoints pause for user approval automatically
+- Model selection follows the `## Model` section in each agent definition
+
+**Tips**:
+
+- Use `/plan-feature <description>` to start a new feature
+- Use `/build-feature #<issue-number>` to implement from a GitHub issue
+- Skills chain naturally — each suggests the next step when done
+
+### Cursor (Partial Support)
+
+Cursor can follow skill workflows by reading SKILL.md files as context, but lacks native slash command support and Task subagents.
+
+**Setup**:
+
+1. Install the package: `npx skills add andrewvaughan/agent-council`
+2. Point Cursor to `AGENTS.md` as project context
+
+**Usage**:
+
+1. Open the relevant `skills/<skill-name>/SKILL.md` file
+2. Tell Cursor: "Follow the workflow in this file"
+3. At checkpoints, Cursor will present its work for your review
+4. For council steps, ask Cursor to evaluate from each member's perspective sequentially
+
+**Limitations**:
+
+- Council members evaluate sequentially, not in parallel
+- No automatic model selection — Cursor uses its configured model for all agents
+- Slash command invocation not supported — reference skill files directly
+- GitHub CLI commands may need to be run manually in the terminal
+
+**Workarounds**:
+
+- For council evaluation, prompt: "Now evaluate this as the Security Engineer, focusing on [their focus areas]"
+- Copy checkpoint output to review before approving continuation
+- Run `gh` commands in Cursor's integrated terminal
+
+### Codex CLI (Partial Support)
+
+Codex CLI can reference AGENTS.md and follow skill workflows step by step.
+
+**Setup**:
+
+1. Install the package: `npx skills add andrewvaughan/agent-council`
+2. Reference AGENTS.md in your Codex configuration
+
+**Usage**:
+
+1. Tell Codex to read `skills/<skill-name>/SKILL.md`
+2. Follow the workflow steps, running commands as needed
+3. At council steps, ask Codex to evaluate from each agent's perspective
+
+**Limitations**:
+
+- No slash command support
+- No Task subagents — council evaluation is sequential
+- No checkpoint pausing — you must manage the flow manually
+- Model selection not supported
+
+### GitHub Copilot (Partial Support)
+
+Copilot can assist with individual steps but cannot orchestrate full workflows autonomously.
+
+**Setup**:
+
+1. Install the package: `npx skills add andrewvaughan/agent-council`
+2. Reference skill workflows in Copilot Chat
+
+**Usage**:
+
+1. Open a SKILL.md file and ask Copilot to help follow the steps
+2. Use Copilot Chat for council-style evaluation by prompting with specific agent perspectives
+3. Run GitHub CLI commands in the terminal
+
+**Limitations**:
+
+- Cannot orchestrate multi-step workflows autonomously
+- No subagent spawning for parallel council evaluation
+- No persistent context between steps — may need to re-reference the workflow
+- Limited file creation and editing compared to Claude Code
+
+### Aider (Partial Support)
+
+Aider can read and edit files following skill workflow instructions.
+
+**Setup**:
+
+1. Install the package: `npx skills add andrewvaughan/agent-council`
+2. Add AGENTS.md and the relevant SKILL.md to Aider's context
+
+**Usage**:
+
+1. Add the skill file: `/add skills/<skill-name>/SKILL.md`
+2. Ask Aider to follow the workflow
+3. At council steps, prompt for each agent's perspective
+
+**Limitations**:
+
+- No slash command support
+- Sequential council evaluation only
+- No checkpoint pausing — manage flow manually
+- Model selection not supported natively (uses configured model)
+
+### Other Agents
+
+Any agent that can read markdown files and follow structured instructions can use Agent Council skills. The general approach:
+
+1. Load the SKILL.md file for the desired workflow
+2. Follow the numbered steps in order
+3. At council steps, evaluate from each listed agent's perspective using the agent definitions in the `agents/` subdirectory
+4. At checkpoints, pause and present work for review
+5. Run shell commands (`git`, `gh`, etc.) as needed
+
+The more capable the agent (file editing, command execution, context retention), the more automated the experience.
+
+## Reporting Compatibility Findings
+
+If you test Agent Council skills with an agent not listed here, or discover new workarounds for listed agents, please report your findings:
+
+1. Open an [Agent Compatibility Report](https://github.com/andrewvaughan/agent-council/issues/new?template=agent-compatibility.yml) issue
+2. Describe which agent and version you tested
+3. Note what worked, what didn't, and any workarounds you found
+
+Community compatibility reports help improve the documentation and identify opportunities for better cross-agent support.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -179,7 +179,7 @@ If your project doesn't have a frontend, you might remove the Frontend Specialis
 
 ## Customizing Skill Workflows
 
-Skill workflows live in `canonical/skills/<skill-name>/SKILL.md`. You can modify any step, add checkpoints, or adjust the workflow to match your team's process.
+Skill workflows live in `canonical/skills/<skill-name>/SKILL.md`. You can modify any step, add checkpoints, or adjust the workflow to match your team's process. For a detailed breakdown of what each skill does and what it produces, see the [Skills Reference](SKILLS-REFERENCE.md).
 
 ### Common Customizations
 
@@ -187,7 +187,7 @@ Skill workflows live in `canonical/skills/<skill-name>/SKILL.md`. You can modify
 
 **Change commit conventions**: If your team uses a different commit format (e.g., Jira ticket references), update the commit step in each skill:
 
-```markdown
+~~~markdown
 ## Step 8: Commit
 
 Commit with your project's commit format:
@@ -195,18 +195,18 @@ Commit with your project's commit format:
 ```
 PROJ-123: implement <feature-name>
 ```
-```
+~~~
 
 **Add team-specific steps**: Insert steps for your team's workflow. For example, adding a design review step to `build-feature`:
 
-```markdown
+~~~markdown
 ### Step 4.5: Design Review
 
 If UI components were created, share screenshots or a Storybook link
 with the design team for feedback before proceeding to testing.
 
 ### CHECKPOINT: Present the design review feedback. Wait for approval.
-```
+~~~
 
 ### After Customizing
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1,0 +1,216 @@
+---
+type: guide
+description: How to adapt Agent Council skills, agents, and councils for your project.
+---
+
+# Customization Guide
+
+Agent Council skills are designed to work with any tech stack and project structure. This guide explains how to configure your project, customize agent personas, and adjust council composition.
+
+## Declaring Your Tech Stack
+
+Implementation skills (`build-feature`, `build-api`) are technology-agnostic — they use phrases like "your project's ORM" and "your project's test runner" instead of naming specific tools. To tell skills what your project uses, add a `## Tech Stack` section to your project's `AGENTS.md`:
+
+```markdown
+## Tech Stack
+
+- Frontend: React with TypeScript
+- Backend: Express with TypeScript
+- ORM: Prisma with PostgreSQL
+- UI: Tailwind CSS + shadcn/ui
+- Validation: Zod
+- State: React Query for server state, Zustand for client state
+- Test runner: Vitest
+- E2E: Playwright
+- Package manager: npm
+```
+
+When a skill reads "use your project's ORM to define the schema," it will check your tech stack and generate Prisma schema code. If you use Django with PostgreSQL instead, the same skill will generate Django models.
+
+> [!IMPORTANT]
+> If the tech stack is not defined, implementation skills will stop and ask you to provide it before proceeding. They will also suggest updating `AGENTS.md` when they introduce new technologies, so the definition stays current.
+
+### What to Include
+
+Include any technology choice that affects how code is written:
+
+| Category | Examples |
+|----------|----------|
+| Frontend | React, Vue, Angular, Svelte, Next.js, Nuxt |
+| Backend | Express, NestJS, Django, Rails, FastAPI, Spring |
+| ORM / Database | Prisma, TypeORM, SQLAlchemy, Sequelize, raw SQL |
+| UI library | Tailwind, Material UI, Chakra, shadcn/ui |
+| Validation | Zod, Joi, Yup, class-validator |
+| State management | React Query, Redux, Zustand, Pinia, Vuex |
+| Test runner | Vitest, Jest, pytest, Mocha |
+| E2E testing | Playwright, Cypress, Selenium |
+| API style | REST, GraphQL, tRPC, gRPC |
+| Package manager | npm, pnpm, yarn, bun |
+| Container | Docker, Podman |
+| CI/CD | GitHub Actions, GitLab CI, CircleCI |
+
+### Tech Stack Updates
+
+When a skill introduces or changes a technology during implementation (e.g., adding a new database, switching a library), it will present the proposed `AGENTS.md` update at a checkpoint for your approval. This ensures the tech stack definition stays accurate across features.
+
+## Modifying Agent Personas
+
+Agent definitions live in `canonical/agents/<agent-name>.md`. Each agent has:
+
+- **Role description**: What perspective this agent brings
+- **Focus areas**: Specific topics this agent evaluates
+- **Complexity tiers**: Standard (routine work) and Advanced (critical decisions)
+- **Model specification**: Which AI model to use for each tier
+
+### Customizing an Existing Agent
+
+To adjust an agent's focus for your domain, edit its definition in `canonical/agents/`. For example, if your project is a healthcare application, you might add HIPAA compliance to the Security Engineer's focus areas:
+
+**Before**:
+
+```markdown
+## Focus Areas
+- OWASP Top 10 vulnerabilities
+- Authentication and authorization patterns
+- Secrets management
+- Input validation and sanitization
+```
+
+**After**:
+
+```markdown
+## Focus Areas
+- OWASP Top 10 vulnerabilities
+- Authentication and authorization patterns
+- Secrets management
+- Input validation and sanitization
+- HIPAA compliance and PHI data handling
+- Audit logging for regulatory requirements
+```
+
+After editing, run `scripts/build.sh` to regenerate the skill packages.
+
+### Adding a New Agent
+
+1. Create `canonical/agents/<agent-name>.md` following the format of existing agents
+2. Add the agent to relevant councils in `canonical/councils/`
+3. Update `scripts/skill-manifest.json` for any skills that should include this agent
+4. Update the agent table in `AGENTS.md`
+5. Run `scripts/build.sh` to regenerate
+
+Example: Adding a **Database Administrator** agent for a data-heavy project:
+
+```markdown
+---
+name: Database Administrator
+role: Database design and optimization specialist
+---
+
+# Database Administrator
+
+## Role
+Evaluates database design decisions, query performance, migration safety,
+and data integrity from a DBA perspective.
+
+## Focus Areas
+- Schema design and normalization
+- Query performance and indexing strategy
+- Migration safety and rollback plans
+- Data integrity constraints
+- Backup and recovery
+- Connection pooling and resource management
+
+## Model
+
+- **Standard**: Sonnet — routine schema reviews, index suggestions
+- **Advanced**: Opus — major schema redesigns, migration strategies for large datasets
+```
+
+## Adjusting Council Composition
+
+Council templates live in `canonical/councils/<council-name>.md`. Each council defines its members, evaluation criteria, and voting format.
+
+### Adding a Member to a Council
+
+To add your new Database Administrator to the Architecture Council:
+
+1. Edit `canonical/councils/architecture-council.md` to include the new member
+2. Update `scripts/skill-manifest.json` to include the agent in skills that use this council
+3. Run `scripts/build.sh` to regenerate
+
+### Removing a Member from a Council
+
+If your project doesn't have a frontend, you might remove the Frontend Specialist from the Feature Council:
+
+1. Edit `canonical/councils/feature-council.md` to remove the member
+2. Update `scripts/skill-manifest.json` to remove the agent from skills that only used it through this council
+3. Run `scripts/build.sh` to regenerate
+
+### Creating a New Council
+
+1. Create `canonical/councils/<council-name>.md` following the existing format:
+
+   ```markdown
+   ---
+   name: <Council Name>
+   description: One-line purpose
+   ---
+
+   # <Council Name>
+
+   ## Members
+   - Agent Name (Lead) — what they evaluate
+   - Agent Name — what they evaluate
+
+   ## Evaluation Criteria
+   - Criterion 1
+   - Criterion 2
+
+   ## Voting Format
+   Each member votes: **Approve** / **Concern** / **Block**
+   - Approve: No issues found
+   - Concern: Issues found but not blocking
+   - Block: Critical issues that must be resolved
+   ```
+
+2. Reference the council from any skills that should activate it
+3. Update `scripts/skill-manifest.json`
+4. Run `scripts/build.sh` to regenerate
+
+## Customizing Skill Workflows
+
+Skill workflows live in `canonical/skills/<skill-name>/SKILL.md`. You can modify any step, add checkpoints, or adjust the workflow to match your team's process.
+
+### Common Customizations
+
+**Adjust checkpoint frequency**: If your team prefers fewer interruptions, remove intermediate checkpoints. If you want more oversight, add checkpoints before significant actions.
+
+**Change commit conventions**: If your team uses a different commit format (e.g., Jira ticket references), update the commit step in each skill:
+
+```markdown
+## Step 8: Commit
+
+Commit with your project's commit format:
+
+```
+PROJ-123: implement <feature-name>
+```
+```
+
+**Add team-specific steps**: Insert steps for your team's workflow. For example, adding a design review step to `build-feature`:
+
+```markdown
+### Step 4.5: Design Review
+
+If UI components were created, share screenshots or a Storybook link
+with the design team for feedback before proceeding to testing.
+
+### CHECKPOINT: Present the design review feedback. Wait for approval.
+```
+
+### After Customizing
+
+Always run `scripts/build.sh` after editing anything in `canonical/` to regenerate the self-contained skill packages in `skills/`. Then run `scripts/build.sh --check` to verify no drift.
+
+> [!IMPORTANT]
+> Never edit files in `skills/` directly — they are overwritten by the build. Always edit sources in `canonical/`.

--- a/docs/SKILLS-REFERENCE.md
+++ b/docs/SKILLS-REFERENCE.md
@@ -61,6 +61,8 @@ Each skill owns a single phase and hands off to the next. Skills never cross the
 | Cursor | Partial | Load SKILL.md as context, run steps manually |
 | Other agents | Manual | Follow the step-by-step workflow |
 
+For setup instructions and workarounds by agent, see [Agent Compatibility](AGENT-COMPATIBILITY.md).
+
 **Next step**: `/build-feature <issue-number>` or `/build-api`
 
 <details>
@@ -135,6 +137,8 @@ Feature Council: Approved (4/4)
 | Cursor | Partial | Follow steps manually, run commands in terminal |
 | Other agents | Manual | Follow the step-by-step workflow |
 
+For setup instructions and workarounds by agent, see [Agent Compatibility](AGENT-COMPATIBILITY.md).
+
 > [!NOTE]
 > This skill requires a `## Tech Stack` section in your project's `AGENTS.md`. If not defined, the skill will stop and ask you to provide it. See [CUSTOMIZATION.md](CUSTOMIZATION.md) for details.
 
@@ -181,8 +185,10 @@ Feature Council: Approved (4/4)
 | Cursor | Partial | Follow steps manually |
 | Other agents | Manual | Follow the step-by-step workflow |
 
+For setup instructions and workarounds by agent, see [Agent Compatibility](AGENT-COMPATIBILITY.md).
+
 > [!NOTE]
-> This skill requires a `## Tech Stack` section in your project's `AGENTS.md`. See [CUSTOMIZATION.md](CUSTOMIZATION.md).
+> This skill requires a `## Tech Stack` section in your project's `AGENTS.md`. If not defined, the skill will stop and ask you to provide it. See [CUSTOMIZATION.md](CUSTOMIZATION.md) for details.
 
 **Next step**: `/review-code`
 
@@ -227,6 +233,8 @@ Feature Council: Approved (4/4)
 | Claude Code | Full | Parallel council via Task subagents, automated scanning |
 | Cursor | Partial | Follow checklist manually, run checks in terminal |
 | Other agents | Manual | Follow the step-by-step workflow |
+
+For setup instructions and workarounds by agent, see [Agent Compatibility](AGENT-COMPATIBILITY.md).
 
 **Next step**: `/submit-pr`
 
@@ -302,6 +310,8 @@ Overall: Needs Changes (fix H1, recommended M1)
 | Cursor | Partial | Create PR manually, monitor CI in browser |
 | Other agents | Manual | Follow the checklist, use platform tools |
 
+For setup instructions and workarounds by agent, see [Agent Compatibility](AGENT-COMPATIBILITY.md).
+
 **Next step**: None — this is the end of the pipeline. After merge, run `/plan-feature` for the next feature.
 
 ---
@@ -341,6 +351,8 @@ Overall: Needs Changes (fix H1, recommended M1)
 | Claude Code | Full | Parallel council, automated scanning, remediation |
 | Cursor | Partial | Follow checklist manually, apply fixes in editor |
 | Other agents | Manual | Follow the step-by-step workflow |
+
+For setup instructions and workarounds by agent, see [Agent Compatibility](AGENT-COMPATIBILITY.md).
 
 **Next step**: `/review-code` (if code changed), `/plan-feature` (new feature), or none (audit-only).
 

--- a/docs/SKILLS-REFERENCE.md
+++ b/docs/SKILLS-REFERENCE.md
@@ -1,0 +1,361 @@
+---
+type: reference
+description: Complete per-skill documentation with step summaries, outputs, and compatibility.
+---
+
+# Skills Reference
+
+Detailed documentation for each skill in the Agent Council package. For installation and quick start, see [README.md](../README.md).
+
+## Pipeline Overview
+
+```mermaid
+graph LR
+    A[plan-feature] --> B[build-feature]
+    A --> C[build-api]
+    B --> D[review-code]
+    C --> D
+    D --> E[submit-pr]
+    F[security-audit] -.-> |standalone| D
+```
+
+Each skill owns a single phase and hands off to the next. Skills never cross their scope boundary — `build-feature` commits code but never creates a PR, `review-code` reviews and fixes but never pushes.
+
+---
+
+## plan-feature
+
+**Purpose**: Take a feature idea through critical analysis and two council reviews to produce an approved implementation plan with decision records.
+
+**When to use**: Starting any new feature work. Run this before `build-feature` or `build-api`.
+
+**What it does**:
+
+1. Gathers feature context — what, who, why, constraints
+2. Runs critical analysis — stress-tests assumptions, asks pointed questions, makes recommendations
+3. Activates the **Product Council** (6 members) — evaluates strategic fit, priority, and user value
+4. Defines lean scope — MVP boundaries, deferred work, feature flags, success metrics
+5. Activates the **Feature Council** (4 members) — produces a technical task breakdown
+6. Generates a decision record in `docs/decisions/`
+7. Creates a feature branch and commits the decision record
+8. Creates GitHub issue(s) with the full implementation plan
+
+**Councils activated**:
+
+| Council | Members | What it evaluates |
+|---------|---------|-------------------|
+| Product | Product Strategist (Lead), Lean Delivery Lead, Design Lead, Business Ops Lead, Principal Engineer, Frontend Specialist | Strategic fit, scope, priority, user value |
+| Feature | Principal Engineer (Lead), Frontend Specialist, Backend Specialist, QA Lead | Technical breakdown, risks, implementation approach |
+
+**Outputs**:
+
+- Decision record at `docs/decisions/NNN-<feature-slug>.md`
+- Feature branch (`feature/<feature-slug>`)
+- GitHub issue(s) with implementation plan, council votes, and task checkboxes
+
+**Compatibility**:
+
+| Agent | Support | Notes |
+|-------|---------|-------|
+| Claude Code | Full | Slash command, parallel council via Task subagents |
+| Cursor | Partial | Load SKILL.md as context, run steps manually |
+| Other agents | Manual | Follow the step-by-step workflow |
+
+**Next step**: `/build-feature <issue-number>` or `/build-api`
+
+<details>
+<summary>Example output</summary>
+
+The skill produces a GitHub issue like:
+
+```
+Title: Implement user notification preferences
+
+## Implementation Plan
+### Database
+- [ ] Add notification_preferences table with user_id FK
+- [ ] Add preference_type enum (email, push, in-app)
+
+### Backend
+- [ ] Create notification preferences service
+- [ ] Add CRUD endpoints for preferences
+- [ ] Add preference check to notification dispatch
+
+### Frontend
+- [ ] Create preferences settings page
+- [ ] Add toggle components for each channel
+- [ ] Wire to API with optimistic updates
+
+### Testing
+- [ ] Unit tests for preference service
+- [ ] Integration tests for API endpoints
+- [ ] E2E test for preference toggle flow
+
+## Council Votes
+Product Council: Approved (6/6)
+Feature Council: Approved (4/4)
+```
+
+</details>
+
+---
+
+## build-feature
+
+**Purpose**: Execute a full-stack feature implementation across database, backend, frontend, and testing layers following an approved plan.
+
+**When to use**: After `plan-feature` has produced an approved implementation plan, or when you have a clear set of tasks to implement across the stack.
+
+**What it does**:
+
+1. Loads the implementation plan from a GitHub issue, decision record, or user description
+2. Implements the **database layer** — schema changes, migrations (checkpoint for approval)
+3. Implements the **backend** — types, services, API layer, tests (checkpoint on API contract)
+4. Implements the **frontend** — components, state, routing, API integration, tests (checkpoint)
+5. Writes **end-to-end tests** for critical user flows
+6. Runs self-review — type check, lint, format, all tests
+7. Updates documentation if the feature changes setup or tech stack
+8. Commits with conventional commit format (checkpoint for approval)
+9. Tracks any deferred work as GitHub issues
+
+**Councils activated**: None — relies on the plan already produced by `plan-feature`.
+
+**Outputs**:
+
+- Committed code across all layers (database, backend, frontend, tests)
+- Conventional commits (`feat(db):`, `feat(api):`, `feat(web):`, `test:`)
+- GitHub issue comment marking progress
+- Deferred-work issues (if applicable)
+
+**Compatibility**:
+
+| Agent | Support | Notes |
+|-------|---------|-------|
+| Claude Code | Full | Reads issue via `gh`, commits, comments on issues |
+| Cursor | Partial | Follow steps manually, run commands in terminal |
+| Other agents | Manual | Follow the step-by-step workflow |
+
+> [!NOTE]
+> This skill requires a `## Tech Stack` section in your project's `AGENTS.md`. If not defined, the skill will stop and ask you to provide it. See [CUSTOMIZATION.md](CUSTOMIZATION.md) for details.
+
+**Next step**: `/review-code`
+
+---
+
+## build-api
+
+**Purpose**: Build backend API endpoints, services, and database changes. Activates the Architecture Council for significant API decisions.
+
+**When to use**: Backend-only work — new API routes, business logic, database schema changes, or microservice patterns.
+
+**What it does**:
+
+1. Defines API requirements from a decision record or user description
+2. Designs the full API contract — endpoints, types, validation, errors, auth
+3. Optionally activates the **Architecture Council** for significant API decisions (checkpoint)
+4. Implements the **database layer** if schema changes are needed (checkpoint)
+5. Implements **backend** — types, repository layer, services, controllers, middleware
+6. Writes **tests** — unit, integration, validation (>80% coverage target)
+7. Generates or updates API documentation
+8. Runs self-review — type check, lint, format, all tests
+9. Updates documentation if the change affects setup or tech stack
+10. Commits with conventional format
+
+**Councils activated** (conditional):
+
+| Council | Members | When activated |
+|---------|---------|----------------|
+| Architecture | Principal Engineer, Platform Engineer, Security Engineer, Backend Specialist | Significant API decisions — new resource types, breaking changes, new architectural patterns |
+
+**Outputs**:
+
+- Committed backend code (types, services, controllers, middleware, tests)
+- API documentation updates
+- Conventional commits (`feat(api):`)
+
+**Compatibility**:
+
+| Agent | Support | Notes |
+|-------|---------|-------|
+| Claude Code | Full | Parallel council via Task subagents, `gh` integration |
+| Cursor | Partial | Follow steps manually |
+| Other agents | Manual | Follow the step-by-step workflow |
+
+> [!NOTE]
+> This skill requires a `## Tech Stack` section in your project's `AGENTS.md`. See [CUSTOMIZATION.md](CUSTOMIZATION.md).
+
+**Next step**: `/review-code`
+
+---
+
+## review-code
+
+**Purpose**: Run a comprehensive, multi-perspective code review with automated security scanning and a 4-member Review Council.
+
+**When to use**: Before creating a pull request, or any time you want a thorough review of your changes.
+
+**What it does**:
+
+1. Analyzes all changes on the current branch relative to main
+2. Runs **formatting and lint checks** — auto-fixes mechanical issues
+3. Runs **automated SAST scanning** — injection, XSS, CSRF, secrets, auth, CVEs
+4. Runs **accessibility audit** if frontend files changed — WCAG, ARIA, keyboard nav
+5. Activates the **Review Council** (4 members) — each member reviews from their perspective
+6. Presents a **consolidated review report** organized by severity (checkpoint)
+7. Applies fixes the user approves, re-runs checks to verify each (checkpoint)
+8. Commits fixes with conventional format
+9. Tracks deferred findings as GitHub issues
+
+**Councils activated**:
+
+| Council | Members | What they review |
+|---------|---------|------------------|
+| Review | Security Engineer (Lead), QA Lead, DevX Engineer, Domain Specialist* | Security, testing, documentation, domain patterns |
+
+*Domain Specialist is Frontend Specialist, Backend Specialist, or both — selected based on which files changed.
+
+**Outputs**:
+
+- Consolidated review report with severity-organized findings and council votes
+- Committed fixes (`fix(security):`, `refactor:`, etc.)
+- Deferred-finding issues (if applicable)
+
+**Compatibility**:
+
+| Agent | Support | Notes |
+|-------|---------|-------|
+| Claude Code | Full | Parallel council via Task subagents, automated scanning |
+| Cursor | Partial | Follow checklist manually, run checks in terminal |
+| Other agents | Manual | Follow the step-by-step workflow |
+
+**Next step**: `/submit-pr`
+
+<details>
+<summary>Example review report</summary>
+
+```
+## Review Council Report
+
+### Critical / Blocking Issues
+None
+
+### High Priority Issues
+H1: SQL injection risk in search endpoint (Security Engineer — Block)
+    File: src/api/search.ts:42
+    Fix: Use parameterized query instead of string interpolation
+
+### Medium Priority Issues
+M1: Missing test coverage for error path (QA Lead — Concern)
+    File: src/services/user.ts:88
+    Fix: Add test for invalid input handling
+
+### Low Priority / Suggestions
+L1: Consider adding JSDoc to exported function (DevX Engineer)
+
+### Council Votes
+- Security Engineer: Concern (H1 must be fixed)
+- QA Lead: Concern (M1 recommended)
+- DevX Engineer: Approve
+- Backend Specialist: Approve
+
+Overall: Needs Changes (fix H1, recommended M1)
+```
+
+</details>
+
+---
+
+## submit-pr
+
+**Purpose**: Create a well-documented pull request with quality checks, conventional formatting, and CI monitoring.
+
+**When to use**: When your feature branch is ready to merge to main, typically after `review-code`.
+
+**What it does**:
+
+1. Runs **pre-submission checks** — confirms feature branch, rebases on main, runs type-check/lint/format/test/build, security scan
+2. Analyzes changes — commits, file diff, type of change, related issues
+3. Optionally activates the **Deployment Council** for production-impacting changes (checkpoint)
+4. Generates a **PR description** from the PR template — title, body, checklist, changelog entry (checkpoint)
+5. Pushes the branch and creates the PR
+6. **Monitors CI** — watches the pipeline, auto-fixes formatting failures, checkpoints for other failures
+7. Presents a post-PR summary with the PR URL and CI status
+
+**Councils activated** (conditional):
+
+| Council | Members | When activated |
+|---------|---------|----------------|
+| Deployment | Platform Engineer (Lead), Security Engineer, QA Lead | Database migrations, infrastructure changes, env var changes, auth code changes, CI/CD modifications |
+
+**Outputs**:
+
+- Pushed feature branch
+- GitHub pull request with full description
+- CI monitoring result
+- Optional changelog entry
+
+**Compatibility**:
+
+| Agent | Support | Notes |
+|-------|---------|-------|
+| Claude Code | Full | `gh pr create`, `gh run watch`, automated CI monitoring |
+| Cursor | Partial | Create PR manually, monitor CI in browser |
+| Other agents | Manual | Follow the checklist, use platform tools |
+
+**Next step**: None — this is the end of the pipeline. After merge, run `/plan-feature` for the next feature.
+
+---
+
+## security-audit
+
+**Purpose**: Run a comprehensive security audit combining SAST scanning, STRIDE threat modeling, and attack tree analysis.
+
+**When to use**: Before major releases, after security-sensitive changes, or on a regular cadence. Can audit the full codebase or specific directories.
+
+**What it does**:
+
+1. Defines audit scope — full codebase or specific area, trigger, focus areas (checkpoint)
+2. Runs **automated SAST scanning** — injection, XSS, CSRF, auth, secrets, CVEs, deserialization, prototype pollution
+3. Performs **security hardening review** — HTTP headers, API security, auth/authz, data protection, infrastructure
+4. Conducts **STRIDE threat modeling** — Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege
+5. Builds **attack trees** for the top 3 highest-risk threats — goals, paths, sub-goals, resources, defenses, weakest links
+6. Activates the **Architecture Council** (security subset, 3 members) — validates findings, assesses posture, identifies systemic patterns
+7. Presents the **full audit report** — executive summary, findings by severity, threat model, recommended actions (checkpoint)
+8. Optionally **remediates** — fixes in priority order, re-scans, commits
+
+**Councils activated**:
+
+| Council | Members | What they evaluate |
+|---------|---------|-------------------|
+| Architecture (subset) | Security Engineer (Lead), Principal Engineer, Backend Specialist | Findings validation, security posture, systemic patterns |
+
+**Outputs**:
+
+- Structured security audit report (executive summary, SAST findings, STRIDE table, attack trees, recommendations)
+- Optional committed security fixes (`fix(security):`)
+
+**Compatibility**:
+
+| Agent | Support | Notes |
+|-------|---------|-------|
+| Claude Code | Full | Parallel council, automated scanning, remediation |
+| Cursor | Partial | Follow checklist manually, apply fixes in editor |
+| Other agents | Manual | Follow the step-by-step workflow |
+
+**Next step**: `/review-code` (if code changed), `/plan-feature` (new feature), or none (audit-only).
+
+<details>
+<summary>Example STRIDE entry</summary>
+
+```
+## Threat: Session Hijacking (Spoofing)
+
+- Likelihood: Medium
+- Impact: High
+- Risk Score: High
+- Current Mitigations: HTTPS, HttpOnly cookies, session expiry
+- Gaps: No session rotation on privilege change, no concurrent session limits
+- Recommended: Add session rotation after login, limit to 3 concurrent sessions
+```
+
+</details>

--- a/skills/build-api/SKILL.md
+++ b/skills/build-api/SKILL.md
@@ -11,6 +11,9 @@ Build backend API endpoints, services, and database changes following your proje
 > **Scope boundary**: This skill implements backend code and commits it. It does **NOT** create pull requests, push to remote, run code reviews, or submit anything for merge. When implementation and commits are complete, **stop** and suggest the user run `/review-code` next.
 
 > [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
+> [!WARNING]
 > **Tech stack required.** This skill adapts to your project's technology choices. If `AGENTS.md` does not specify a backend framework, ORM, API style, validation library, or test runner, **stop and ask the user** what their project uses. Then update `AGENTS.md` with a `## Tech Stack` section so future skills can reference it automatically. Example:
 >
 >     ## Tech Stack

--- a/skills/build-feature/SKILL.md
+++ b/skills/build-feature/SKILL.md
@@ -11,6 +11,9 @@ Execute a full-stack feature implementation across database, backend, frontend, 
 > **Scope boundary**: This skill implements code and commits it. It does **NOT** create pull requests, push to remote, run code reviews, or submit anything for merge. When implementation and commits are complete, **stop** and suggest the user run `/review-code` next. Do not proceed to PR creation — that is `/submit-pr`'s job.
 
 > [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
+> [!WARNING]
 > **Tech stack required.** This skill adapts to your project's technology choices. If `AGENTS.md` does not specify your project's frameworks, ORM, UI library, or test runner, **stop and ask the user** what their project uses. Then update `AGENTS.md` with a `## Tech Stack` section so future skills can reference it automatically. Example:
 >
 >     ## Tech Stack

--- a/skills/plan-feature/SKILL.md
+++ b/skills/plan-feature/SKILL.md
@@ -10,6 +10,9 @@ Take a feature idea from concept to an approved implementation plan with lean sc
 > [!CAUTION]
 > **Scope boundary**: This skill produces a _plan_, a decision record, and issue(s) in your project tracker. It does **NOT** write application code, create components, modify database schemas, run tests, create branches for implementation, or perform any build work. If the user asks to start building after the plan is approved, direct them to run `/build-feature <issue-number>` — do not begin implementation yourself.
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Gather Feature Context
 
 Ask the user to describe:

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -10,6 +10,9 @@ Run a comprehensive, multi-perspective code review on the current branch changes
 > [!CAUTION]
 > **Scope boundary**: This skill reviews code and commits fixes. It does **NOT** create pull requests, push to remote, or merge anything. When the review is complete, **stop** and suggest the user run `/submit-pr` next. Do not proceed to PR creation — that is `/submit-pr`'s job.
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Analyze Current Changes
 
 Identify all changes on the current branch:

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -10,6 +10,9 @@ Run a comprehensive security audit that combines automated static analysis, thre
 > [!CAUTION]
 > **Scope boundary**: This skill audits code and optionally remediates findings. It does **NOT** create pull requests, push to remote, or merge anything. When the audit is complete, **stop** and suggest the appropriate next step (see Step 9).
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Define Audit Scope
 
 Ask the user:

--- a/skills/submit-pr/SKILL.md
+++ b/skills/submit-pr/SKILL.md
@@ -10,6 +10,9 @@ Create a well-documented pull request for the current feature branch, following 
 > [!CAUTION]
 > **Scope boundary**: This skill pushes code, creates pull requests, monitors CI, and commits CI fixes (with user approval). It does **NOT** implement new features or run formal code reviews. When the PR is created and CI passes, **stop** — the workflow is complete.
 
+> [!WARNING]
+> **Checkpoint protocol.** When this workflow reaches a `### CHECKPOINT`, you **must** actively prompt the user for a decision — do not simply present information and continue. Use your agent's interactive prompting mechanism (e.g., `AskUserQuestion` in Claude Code) to require an explicit response before proceeding. This prevents queued or in-flight messages from being misinterpreted as approval. If your agent lacks interactive prompting, output the checkpoint content and **stop all work** until the user explicitly responds.
+
 ## Step 1: Pre-Submission Checks
 
 Verify the branch is ready for a pull request:


### PR DESCRIPTION
## Description

Adds three supplementary documentation files, an agent compatibility issue template, and a checkpoint protocol to all skill workflows. Also fixes 4 incorrect agent names in README.md and adds cross-references between all documentation files.

## Type of Change

- [ ] New skill, agent, or council
- [x] Improvement to existing skill/agent/council
- [ ] Bug fix (workflow correction)
- [x] Documentation update
- [ ] Build/CI change
- [ ] Chore (dependencies, configs)

## Related Issues

Closes #5

## Changes Made

**New documentation:**
- `docs/SKILLS-REFERENCE.md` — per-skill documentation with purpose, step summaries, councils activated, outputs, compatibility tables, and collapsible example output
- `docs/AGENT-COMPATIBILITY.md` — feature matrix across 6 agent platforms (Claude Code, Cursor, Codex CLI, Copilot, Aider, Other) with per-agent setup, usage, limitations, and workarounds
- `docs/CUSTOMIZATION.md` — tech stack declaration, agent persona customization with before/after examples, council composition changes, skill workflow customization

**New GitHub template:**
- `.github/ISSUE_TEMPLATE/agent-compatibility.yml` — community template for reporting cross-agent compatibility findings

**Skill improvements:**
- Added checkpoint protocol warning to all 6 skills requiring agents to use interactive prompting (e.g., `AskUserQuestion`) at checkpoints instead of continuing on queued messages

**Documentation fixes (from review council):**
- Fixed 4 incorrect agent names in README.md (Product Manager → Product Strategist, Technical Writer → Lean Delivery Lead, UX Designer → Design Lead, Data Analyst → Business Operations Lead)
- Added forward references from README sections to detailed docs
- Added cross-references between all 3 new docs
- Fixed nested code block rendering in CUSTOMIZATION.md
- Added missing `/build-api` and `/security-audit` to AGENT-COMPATIBILITY.md Claude Code slash command list
- Fixed truncated build-api NOTE block in SKILLS-REFERENCE.md

## Testing

- [x] `scripts/build.sh --check` passes (no drift)
- [x] All CI checks pass locally or expected to pass
- [x] Manually reviewed changed skill workflows for correctness

## Checklist

- [x] No technology-specific terms in SKILL.md files
- [x] No personal paths in committed files
- [x] Documentation updated (if user-facing change)
- [ ] AGENTS.md updated (if adding/modifying skills, agents, or councils)
- [x] README.md updated (if changing counts or package description)

## Breaking Changes

N/A

## Deployment Notes

N/A